### PR TITLE
Update `semver` and `chrono` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-chrono = "0.4.15"
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 log = "0.4.11"
 regex = "1.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 log = "0.4.11"
 regex = "1.3.9"
 serde = { version = "1.0.115", features = ["derive"] }
-semver = "0.10.0"
+semver = "1.0.14"
 serde_json = "1.0.57"
 sha1 = { version = "0.10.1", features = ["std"] }
 base16ct = { version = "0.1.1", features = ["alloc"] }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -77,7 +77,7 @@ pub fn evaluate<'a>(
     }
 
     for (rule_index, rule) in flag.rules.iter().enumerate() {
-        if rule.matches(user, &*store) {
+        if rule.matches(user, store) {
             let result = flag.resolve_variation_or_rollout(&rule.variation_or_rollout, user);
             return match result {
                 Ok(BucketResult {
@@ -111,7 +111,7 @@ pub fn evaluate<'a>(
 
 /// A Detail instance is returned from [evaluate], combining the result of a flag evaluation with
 /// an explanation of how it was calculated.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Detail<T> {
     /// The result of the flag evaluation. This will be either one of the flag's variations or None
     /// if no appropriate fallback value was configured.
@@ -243,7 +243,7 @@ impl<T> Detail<T> {
 }
 
 /// Reason describes the reason that a flag evaluation produced a particular value.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE", tag = "kind")]
 pub enum Reason {
     /// Off indicates that the flag was off and therefore returned its configured off value.
@@ -305,7 +305,7 @@ impl Reason {
 
 /// Error is returned via a [Reason::Error] when the client could not evaluate a flag, and
 /// provides information about why the flag could not be evaluated.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Error {
     /// ClientNotReady indicates that the caller tried to evaluate a flag before the client

--- a/src/user.rs
+++ b/src/user.rs
@@ -165,6 +165,10 @@ impl AttributeValue {
         semver::Version::parse(version_str)
             .ok()
             .or_else(|| AttributeValue::parse_semver_loose(version_str))
+            .map(|mut version| {
+                version.build = semver::BuildMetadata::EMPTY;
+                version
+            })
     }
 
     fn parse_semver_loose(version_str: &str) -> Option<semver::Version> {

--- a/src/user.rs
+++ b/src/user.rs
@@ -140,9 +140,8 @@ impl AttributeValue {
     /// It will return None if the conversion fails or if no conversion is possible.
     pub fn to_datetime(&self) -> Option<chrono::DateTime<Utc>> {
         match self {
-            AttributeValue::Number(millis) => {
-                f64_to_i64_safe(*millis).map(|millis| Utc.timestamp_millis(millis))
-            }
+            AttributeValue::Number(millis) => f64_to_i64_safe(*millis)
+                .and_then(|millis| Utc.timestamp_millis_opt(millis).single()),
             AttributeValue::String(s) => chrono::DateTime::parse_from_rfc3339(s)
                 .map(|dt| dt.with_timezone(&Utc))
                 .ok(),

--- a/src/variation.rs
+++ b/src/variation.rs
@@ -22,7 +22,7 @@ impl From<&VariationIndex> for BucketResult {
 
 /// RolloutKind describes whether a rollout is a simple percentage rollout or represents an
 /// experiment. Experiments have different behaviour for tracking and variation bucketing.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum RolloutKind {
     /// Represents a simple percentage rollout. This is the default rollout kind, and will be assumed if


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

* Bumped up the `semver` and `chrono` dependencies.
* For the latter, removed the now obsolete `clock` dependency (see chronotope/chrono#478).
* Fixed failing tests and errors reported by `cargo clippy --all-features -- -D warnings`.

**Describe alternatives you've considered**

We need to bump the dependencies in order to integrate with [MaterializeInc/materialize](https://github.com/MaterializeInc/materialize).

**Additional context**

Add any other context about the pull request here.
