### PR TITLE
refactor: Expose unbounded context kind as field instead of method

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -36,7 +36,9 @@ pub struct Segment {
     #[serde(default)]
     pub unbounded: bool,
     #[serde(default)]
-    unbounded_context_kind: Option<Kind>,
+    /// Unbounded segments target specific, individual context kinds. If this value is not
+    /// provided, it is assumed to be the user kind.
+    pub unbounded_context_kind: Option<Kind>,
     #[serde(default)]
     generation: Option<i64>,
 
@@ -194,15 +196,6 @@ impl Segment {
         }
 
         false
-    }
-
-    /// Returns the context kind for this unbounded (big) segment, or None if not set.
-    ///
-    /// When evaluating big segment membership, callers should default to [`Kind::user`] if this
-    /// returns None, and then use [`Context::as_kind`] to find the matching single-kind context
-    /// whose key should be used for the membership lookup.
-    pub fn unbounded_context_kind(&self) -> Option<&Kind> {
-        self.unbounded_context_kind.as_ref()
     }
 
     /// Retrieve the id representing this big segment.
@@ -779,22 +772,6 @@ mod tests {
     #[test]
     fn unbounded_context_kind_accessor_returns_none_when_unset() {
         let segment = new_segment();
-        assert_eq!(segment.unbounded_context_kind(), None);
-    }
-
-    #[test]
-    fn unbounded_context_kind_accessor_returns_kind_when_set() {
-        let mut segment = new_segment();
-        segment.unbounded = true;
-        segment.unbounded_context_kind = Some(Kind::from("org"));
-        assert_eq!(segment.unbounded_context_kind(), Some(&Kind::from("org")));
-    }
-
-    #[test]
-    fn unbounded_context_kind_accessor_returns_user_kind() {
-        let mut segment = new_segment();
-        segment.unbounded = true;
-        segment.unbounded_context_kind = Some(Kind::user());
-        assert_eq!(segment.unbounded_context_kind(), Some(&Kind::user()));
+        assert_eq!(segment.unbounded_context_kind, None);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a public API change: callers must access `Segment::unbounded_context_kind` directly instead of the removed accessor method, which can break downstream code but does not alter evaluation logic.
> 
> **Overview**
> Refactors `Segment` to expose `unbounded_context_kind` as a public field (with clarified docs) and removes the `unbounded_context_kind()` accessor method.
> 
> Updates tests to assert against the field directly, eliminating now-redundant accessor coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8fd761efaf80d792df892ba7d13058954dea57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->