### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main` was updated in [gh-actions#86](https://github.com/launchdarkly/gh-actions/pull/86) to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller grants. Since this caller had no `permissions` block, the reusable workflow's permission request cannot be satisfied, causing every run to hit `startup_failure`.

Same fix as [sdk-meta#429](https://github.com/launchdarkly/sdk-meta/pull/429), applied across SDK repositories.

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` workflow run on this PR exits `success` rather than `startup_failure`

### Notes

No product code is changed — workflow-only permissions fix. Only `pull-requests: read` is granted, matching the minimum scope the reusable workflow requires.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that minimally expands GitHub token scope to `pull-requests: read` so the reusable lint workflow can start; no product/runtime code paths are affected.
> 
> **Overview**
> Fixes `Lint PR title` runs failing at startup by granting the workflow `permissions: pull-requests: read`, allowing the called reusable workflow to obtain the required PR read access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ed3c7b27dad8e9cc49d071a182330f27826911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->